### PR TITLE
Add correct fullscreen attributes onto 

### DIFF
--- a/src/components/splashBackground.jsx
+++ b/src/components/splashBackground.jsx
@@ -9,9 +9,7 @@ const SplashBackground = () => (
       id="splash-background__video"
       src="//player.vimeo.com/video/177154800?api=1&background=1"
       frameBorder="0"
-      webkitallowfullscreen
-      mozallowfullscreen
-      allowFullScreen
+      allow="fullscreen"
     />
   </div>
 );

--- a/src/components/videoPlayer.jsx
+++ b/src/components/videoPlayer.jsx
@@ -22,9 +22,7 @@ class VideoPlayer extends React.Component {
           width="640"
           height="272"
           frameBorder="0"
-          webkitallowfullscreen
-          mozallowfullscreen
-          allowFullScreen
+          allow="fullscreen"
         />
       </div>
     );


### PR DESCRIPTION
This fixes #4. The attributes on the video iframes was incompatible with React so it would throw console errors on page load. 