### PR TITLE
Prevent video iframe from causing mobile site to overflow

### DIFF
--- a/src/less/videoPlayer.less
+++ b/src/less/videoPlayer.less
@@ -31,6 +31,10 @@
       height: 100%;
       width: 100%;
     }
+
+    @media @smallScreen, @phone{
+      width: 100vw;
+    }
   }
 
   .close-icon {


### PR DESCRIPTION
Fix Issue #25. The video iframe caused the page to overflow. 