### PR TITLE
Remove unnecessary encoding from Twitter text

### DIFF
--- a/src/components/plainPageContent/contactContent.jsx
+++ b/src/components/plainPageContent/contactContent.jsx
@@ -19,7 +19,7 @@ const ContactContent = ({ emailAddress, emailSubject, bodyCopy }) => (
     />
     <Button
       buttonText="Contact Us"
-      url={`mailto:${emailAddress}?subject=${encodeURI(emailSubject)}`}
+      url={`mailto:${emailAddress}?subject=${emailSubject}`}
     />
   </article>
 );

--- a/src/shareLinkUrls.js
+++ b/src/shareLinkUrls.js
@@ -7,7 +7,7 @@ function getShareLinkUrl(type, url, sharingText) {
     case ShareLinkType.Email:
       return encodeURI(`mailto:?subject=${'The Noted Project'}&body=${url}`);
     case ShareLinkType.Twitter:
-      return encodeURI(`https://twitter.com/intent/tweet?url=https://${encodeURI(url)}&text=${encodeURIComponent(sharingText)}`);
+      return encodeURI(`https://twitter.com/intent/tweet?url=https://${encodeURI(url)}&text=${sharingText}`);
     default:
       return url;
   }


### PR DESCRIPTION
Fix issue #44. React encodes url strings already. Intentionally encoding the existing text mangles it. 